### PR TITLE
Fixed select & popupButton styling

### DIFF
--- a/src/renderer/components/chat/Chat.tsx
+++ b/src/renderer/components/chat/Chat.tsx
@@ -6,6 +6,7 @@ import {
   PageContent,
   PageTitleRight
 } from '../generic-styled-components/Page';
+import { SelectWrap } from '../generic-styled-components/Select'
 import { ChatInput } from './chatInput';
 import { getPhrase } from '@/renderer/helpers/lang';
 import { FaUserAlt, FaMicrophone } from 'react-icons/fa';
@@ -49,59 +50,6 @@ const ScrollTo = styled.div`
   height: 0px;
   width: 0px;
   overflow: hidden;
-`;
-
-interface ISelectProps {
-  textColor?: string;
-  borderColor?: string;
-  selectedColor?: string;
-  backgroundColor?: string;
-}
-
-const SelectWrap = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  height: min-conent;
-  padding-left: 10px;
-  width: 170px;
-  font-size: 1em !important;
-  & > div {
-    width: 160px;
-    &:hover {
-      cursor: pointer;
-    }
-  }
-  [class*='-placeholder'],
-  [class*='-singleValue'] {
-    font-size: 0.8em !important;
-  }
-  [class*='-control'] {
-    min-height: 33px;
-    max-height: 33px;
-    background: ${(props: ISelectProps): ThemeSet | string =>
-      props.backgroundColor
-        ? props.backgroundColor
-        : dropDownBoxBackgroundColor
-        ? dropDownBoxBackgroundColor
-        : '#ffffffff'};
-    border-color: ${(props: ISelectProps): ThemeSet | string =>
-      props.borderColor
-        ? props.borderColor
-        : dropDownBoxBorderColor
-        ? dropDownBoxBorderColor
-        : '#727272ff'};
-  }
-  [class*='-singleValue'] {
-    color: ${(props: ISelectProps): ThemeSet | string =>
-      props.textColor
-        ? props.textColor
-        : dropDownBoxColor
-        ? dropDownBoxColor
-        : '#f1f1f1ff'};
-  }
 `;
 
 const CurrentlyConnected = styled.div`
@@ -276,7 +224,7 @@ export const Chat = ({ chat }: { chat: {}[] }): React.ReactElement => {
     <PageMain>
       <PageTitle>
         {getPhrase('chat_name')}{' '}
-        <SelectWrap>
+        <SelectWrap paddingLeft={'20px'}>
           <Select
             menuPlacement='bottom'
             options={[

--- a/src/renderer/components/chat/chatTTSSettings.tsx
+++ b/src/renderer/components/chat/chatTTSSettings.tsx
@@ -10,6 +10,7 @@ import {
   PopupDialogInputInfo,
   PopupDialogInputName
 } from '../generic-styled-components/popupDialog';
+import { SelectWrap } from '../generic-styled-components/Select'
 import { FaTimes } from 'react-icons/fa';
 import { getPhrase } from '@/renderer/helpers/lang';
 import { Button } from '../generic-styled-components/button';
@@ -116,20 +117,22 @@ export const ChatTTSSettings = ({
           <PopupDialogInputName>
             {getPhrase('chat_tts_options')}
           </PopupDialogInputName>
-          <Select
-            value={allowedTTSDonations}
-            isMulti={true}
-            onChange={updateAllowedTTSDonations}
-            menuPortalTarget={document.body}
-            options={[
-              { label: 'Lemon', value: 'LEMON' },
-              { label: 'Ice Cream', value: 'ICE_CREAM' },
-              { label: 'Diamond', value: 'DIAMOND' },
-              { label: 'Ninjaghini', value: 'NINJAGHINI' },
-              { label: 'Ninjet', value: 'NINJET' }
-            ]}
-            isDisabled={!hasTTSDonations}
-          />
+          <SelectWrap width={'100%'}>
+            <Select
+              value={allowedTTSDonations}
+              isMulti={true}
+              onChange={updateAllowedTTSDonations}
+              menuPortalTarget={document.body}
+              options={[
+                { label: 'Lemon', value: 'LEMON' },
+                { label: 'Ice Cream', value: 'ICE_CREAM' },
+                { label: 'Diamond', value: 'DIAMOND' },
+                { label: 'Ninjaghini', value: 'NINJAGHINI' },
+                { label: 'Ninjet', value: 'NINJET' }
+              ]}
+              isDisabled={!hasTTSDonations}
+            />
+          </SelectWrap>
           <PopupDialogInputInfo>
             {getPhrase('chat_tts_options_info')}
           </PopupDialogInputInfo>

--- a/src/renderer/components/commands/AddOrEditCommandPopup.tsx
+++ b/src/renderer/components/commands/AddOrEditCommandPopup.tsx
@@ -11,6 +11,7 @@ import {
   PopupDialogPadding,
   PopupButtonWrapper
 } from '../generic-styled-components/popupDialog';
+import { SelectWrap } from '../generic-styled-components/Select'
 import { FaTimes } from 'react-icons/fa';
 import { getPhrase } from '@/renderer/helpers/lang';
 import { Button } from '../generic-styled-components/button';
@@ -169,18 +170,20 @@ export const AddOrEditCommandPopup = (props: IProps) => {
         <PopupDialogInputName>
           {getPhrase('new_command_info_title')}
         </PopupDialogInputName>
-        <Select
-          value={commandPermissions}
-          isMulti={true}
-          onChange={updateCommandPermissions}
-          options={[
-            { label: 'Viewer', value: 0 },
-            { label: 'Loyal Viewer', value: 1 },
-            { label: 'Subscriber', value: 2 },
-            { label: 'Moderator', value: 3 },
-            { label: 'Owner / Bot', value: 4 }
-          ]}
-        />
+        <SelectWrap width={'100%'}>
+          <Select
+            value={commandPermissions}
+            isMulti={true}
+            onChange={updateCommandPermissions}
+            options={[
+              { label: 'Viewer', value: 0 },
+              { label: 'Loyal Viewer', value: 1 },
+              { label: 'Subscriber', value: 2 },
+              { label: 'Moderator', value: 3 },
+              { label: 'Owner / Bot', value: 4 }
+            ]}
+          />
+        </ SelectWrap>
         <PopupDialogInputInfo>
           {getPhrase('new_command_permissions_info')}
         </PopupDialogInputInfo>

--- a/src/renderer/components/generic-styled-components/Button.tsx
+++ b/src/renderer/components/generic-styled-components/Button.tsx
@@ -29,7 +29,9 @@ export const Button = styled.button`
   disabled -> inverted -> color */
   background: ${(props: IButton): ThemeSet | string =>
     props.disabled
-      ? '#d1d1d1'
+      ? popupButtonDisabledBackgroundColor 
+      ? popupButtonDisabledBackgroundColor 
+      : '#d1d1d1'
       : props.inverted
       ? popupButtonInvertedBackgroundColor 
       ? popupButtonInvertedBackgroundColor 
@@ -49,7 +51,9 @@ export const Button = styled.button`
   /** Makes color light gray on disbaled */
   color: ${(props: IButton): ThemeSet | string =>
     props.disabled 
-    ? '#e1e1e1' 
+    ? popupButtonDisabledColor 
+    ? popupButtonDisabledColor 
+    : '#e1e1e1' 
     : props.inverted 
     ? popupButtonColor 
     ? popupButtonColor 

--- a/src/renderer/components/generic-styled-components/Select.tsx
+++ b/src/renderer/components/generic-styled-components/Select.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { ThemeSet } from 'styled-theming';
+import styled from 'styled-components';
+import {
+    dropDownBoxBackgroundColor,
+    dropDownBoxBorderColor,
+    dropDownBoxHoverColor,
+    dropDownBoxColor,
+    dropDownBoxSelectedColor
+} from '@/renderer/helpers/appearance';
+
+
+interface ISelectProps {
+    textColor?: string;
+    borderColor?: string;
+    selectedColor?: string;
+    backgroundColor?: string;
+    width?: string;
+    paddingLeft?: string;
+    paddingTop?: string;
+    paddingRight?: string;
+    paddingBottom?: string;
+  }
+  
+export const SelectWrap = styled.div`
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: min-content;
+    padding-left: ${(props: ISelectProps): string => props.paddingLeft ? props.paddingLeft : '0px'};
+    padding-top: ${(props: ISelectProps): string => props.paddingTop ? props.paddingTop : '0px'};
+    padding-right: ${(props: ISelectProps): string => props.paddingRight ? props.paddingRight : '0px'};
+    padding-bottom: ${(props: ISelectProps): string => props.paddingBottom ? props.paddingBottom : '0px'};
+    width: ${(props: ISelectProps): string => props.width ? props.width : '175px'};
+    [class*='-container'] {
+        width: 100%;
+        [class*='-menu'] {
+            color: Black !important;
+        }
+    }
+    font-size: 1em !important;
+    & > div {
+      width: 160px;
+      &:hover {
+        cursor: pointer;
+      }
+    }
+    [class*='-placeholder'],
+    [class*='-singleValue'] {
+      font-size: 0.8em !important;
+    }
+    [class*='-placeholder'] {
+      font-size: 1em !important;
+    }
+    [class*='-control'] {
+      min-height: 33px;
+      max-height: 33px;
+      background: ${(props: ISelectProps): ThemeSet | string =>
+        props.backgroundColor
+          ? props.backgroundColor
+          : dropDownBoxBackgroundColor
+          ? dropDownBoxBackgroundColor
+          : '#ffffffff'};
+      border-color: ${(props: ISelectProps): ThemeSet | string =>
+        props.borderColor
+          ? props.borderColor
+          : dropDownBoxBorderColor
+          ? dropDownBoxBorderColor
+          : '#727272ff'};
+    }
+    [class*='-singleValue'] {
+      color: ${(props: ISelectProps): ThemeSet | string =>
+        props.textColor
+          ? props.textColor
+          : dropDownBoxColor
+          ? dropDownBoxColor
+          : '#f1f1f1ff'};
+    }
+  `;

--- a/src/renderer/components/users/UserPoup.tsx
+++ b/src/renderer/components/users/UserPoup.tsx
@@ -13,6 +13,7 @@ import {
   PopupDialogTabPage,
   PopupButtonWrapper
 } from '../generic-styled-components/popupDialog';
+import { SelectWrap } from '../generic-styled-components/Select'
 import { FaTimes } from 'react-icons/fa';
 import { getPhrase } from '@/renderer/helpers/lang';
 import { Button } from '../generic-styled-components/button';
@@ -123,13 +124,15 @@ export const UserPopup = (props: IProps) => {
                 <PopupDialogInputName>
                   {getPhrase('user_popup_permissions')}
                 </PopupDialogInputName>
-                <Select
-                  value={user
-                    .getPermissionStrings()
-                    .map(item => ({ label: item, value: item }))}
-                  isDisabled={true}
-                  isMulti={true}
-                />
+                <SelectWrap width={'100%'}>
+                  <Select
+                    value={user
+                      .getPermissionStrings()
+                      .map(item => ({ label: item, value: item }))}
+                    isDisabled={true}
+                    isMulti={true}
+                  />
+                </SelectWrap>
               </PopupDialogInputWrapper>
               <PopupDialogInputWrapper>
                 <PopupDialogInputName>

--- a/src/renderer/helpers/theme.json
+++ b/src/renderer/helpers/theme.json
@@ -70,8 +70,8 @@
                 "invertedBackgroundColor": "#181818ff",
                 "destructivebackgroundColor": "#df1ebfff",
                 "destructiveColor": "#f1f1f1ff",
-                "disabledBackgroundColor": "#d1d1d1ff",
-                "disabledColor": "#e1e1e1ff"
+                "disabledBackgroundColor": "#121212ff",
+                "disabledColor": "#383838ff"
             },
             "dropDownBox": {
                 "backgroundColor": "#161616ff",


### PR DESCRIPTION
_**Patch Notes**_
- Added `Select.tsx` to Generics which as the `SelectWrap` component from `Chat.tsx`
- Removed `SelectWrap` and `ISelectProp` from `Chat.tsx` (moved to `Select.tsx`)
- Added new override/optional variables in `ISelectProp` [`width`, `paddingLeft`, `paddingTop`, `paddingRight`, `paddingBottom`]
- Fixed Select Boxes in Popups
- Fixed Popup Button Disabled Styling

_**Notes**_
- All Select Components must be wrapped in `SelectWrap` if they want the theming applied to them